### PR TITLE
Support to print view konfig as properties (to easily filter on comma…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ zzz-tmp
 dist
 .pdm-python
 .env
+.idea

--- a/framework/requirements-dev.txt
+++ b/framework/requirements-dev.txt
@@ -1,3 +1,4 @@
 ruamel-yaml   >=0.17.32
 jinja2        >=3.1.2
 cryptography
+flatdict

--- a/framework/requirements-dev.txt
+++ b/framework/requirements-dev.txt
@@ -1,4 +1,3 @@
 ruamel-yaml   >=0.17.32
 jinja2        >=3.1.2
 cryptography
-flatdict

--- a/kreate/kore/_core.py
+++ b/kreate/kore/_core.py
@@ -203,6 +203,11 @@ def pprint_map(map, indent="", file=None):
         for v in map:
             print(f"{indent}- {v}", file=file)
         return
+
+    if map is None:
+        logger.warning("No values present to print")
+        return
+
     for key in sorted(map.keys()):
         val = map.get(key, None)
         if isinstance(val, Mapping):

--- a/kreate/kore/_core.py
+++ b/kreate/kore/_core.py
@@ -219,3 +219,12 @@ def pprint_map(map, indent="", file=None):
                 print(f"{indent}- {v}", file=file)
         else:
             print(f"{indent}{key}: {val}", file=file)
+
+def pprint_tuple(tup, prefix=None, delimiter="."):
+    for item in sorted(tup, key=lambda x: x[0]):
+        if prefix is None:
+            print(f"{item[0]}={item[1]}")
+        else:
+            print(f"{prefix}{delimiter}{item[0]}={item[1]}")
+
+

--- a/kreate/kore/_core.py
+++ b/kreate/kore/_core.py
@@ -1,14 +1,15 @@
+import io
+import logging
+import re
+import sys
 from collections import UserDict, UserList
 from collections.abc import Mapping, Sequence
-import logging
-import io
-import sys
 
 logger = logging.getLogger(__name__)
 
 
 def deep_update(
-    target: Mapping, other: Mapping, overwrite=True, list_insert_index: dict = None
+        target: Mapping, other: Mapping, overwrite=True, list_insert_index: dict = None
 ) -> None:
     if other.get("_do_not_overwrite", False):
         overwrite = False
@@ -225,11 +226,19 @@ def pprint_map(map, indent="", file=None):
         else:
             print(f"{indent}{key}: {val}", file=file)
 
-def pprint_tuple(tup, prefix=None, delimiter="."):
+
+def pprint_tuple(tup, prefix=None, delimiter=".", pattern=None):
     for item in sorted(tup, key=lambda x: x[0]):
         if prefix is None:
-            print(f"{item[0]}={item[1]}")
+            print_filtered(f"{item[0]}={item[1]}", pattern)
         else:
-            print(f"{prefix}{delimiter}{item[0]}={item[1]}")
+            print_filtered(f"{prefix}{delimiter}{item[0]}={item[1]}", pattern)
 
 
+def print_filtered(text, pattern):
+    if pattern is not None:
+        regex_pattern = re.compile(pattern, re.IGNORECASE)
+        if regex_pattern.search(text):
+            print(text)
+    else:
+        print(text)

--- a/kreate/kore/_jinyaml.py
+++ b/kreate/kore/_jinyaml.py
@@ -53,7 +53,6 @@ class JinYaml:
             start = "\n" + indent
         return start + start.join(out.getvalue().splitlines())
 
-
     def add_jinja_filter(self, name, func):
         self.env.filters[name] = func
 
@@ -80,16 +79,28 @@ class JinYaml:
                 logger.error(f"Error when rendering {filename}, {e}")
             raise
 
-    def render(self, fname: str, vars: Mapping) -> Mapping:
+    def render_yaml(self, fname: str, vars: Mapping) -> Mapping:
         self.konfig.tracer.push(f"rendering jinja: {fname}")
         text = self.render_jinja(fname, vars)
         self.konfig.tracer.pop()
         if text is None:
             return None
         self.konfig.tracer.push(f"parsing yaml: {fname}\n" + text)
-        result =  self.yaml_parser.load(text)
+        result = self.yaml_parser.load(text)
         self.konfig.tracer.pop()
         return result
+
+    def render_multi_yaml(self, fname: str, vars: Mapping) -> Mapping:
+        self.konfig.tracer.push(f"rendering jinja: {fname}")
+        text = self.render_jinja(fname, vars)
+        self.konfig.tracer.pop()
+        if text is None:
+            return None
+        self.konfig.tracer.push(f"parsing yaml: {fname}\n" + text)
+        # Support to load multiple documents
+        generator = self.yaml_parser.load_all(text)
+        self.konfig.tracer.pop()
+        return generator
 
     def dump(self, data, output_file):
         self.yaml_parser.dump(data, output_file)

--- a/kreate/kore/_jinyaml.py
+++ b/kreate/kore/_jinyaml.py
@@ -1,15 +1,16 @@
-import os
-from io import StringIO
-import jinja2
-import logging
 import base64
-import warnings
+import logging
+import os
 import traceback
-from sys import exc_info
+import warnings
 from collections.abc import Mapping
+from io import StringIO
+
+import jinja2
 from ruamel.yaml import YAML
 
 logger = logging.getLogger(__name__)
+
 
 def error(msg: str):
     # TODO: is this best Exception?
@@ -62,7 +63,7 @@ class JinYaml:
             if data is None:
                 logger.debug(f"did not find {filename}")
                 return None
-            tmpl = self.env.from_string(data) # self.env.get_template(filename)
+            tmpl = self.env.from_string(data)  # self.env.get_template(filename)
             return tmpl.render(vars)
         except jinja2.exceptions.TemplateSyntaxError as e:
             logger.error(

--- a/kreate/kore/_jinyaml.py
+++ b/kreate/kore/_jinyaml.py
@@ -11,7 +11,6 @@ from ruamel.yaml import YAML
 
 logger = logging.getLogger(__name__)
 
-
 def error(msg: str):
     # TODO: is this best Exception?
     raise RuntimeError(msg)
@@ -26,6 +25,7 @@ class JinYaml:
             trim_blocks=True,
             lstrip_blocks=True,
             loader=RepoLoader(konfig),
+            extensions=['jinja2.ext.debug']
         )
         self.env.globals["konfig"] = konfig
         self.env.globals["jinja_extension"] = {

--- a/kreate/kore/_konfig.py
+++ b/kreate/kore/_konfig.py
@@ -104,7 +104,7 @@ class Konfig:
                     raise ValueError("inklude params should contain = in inklude:{fname}")
                 k,v = item.split("=", 1)
                 context["args"][k] = v
-        val_yaml = self.jinyaml.render(location, context)
+        val_yaml = self.jinyaml.render_yaml(location, context)
         if val_yaml:  # it can be empty
             deep_update(self.yaml, val_yaml, list_insert_index={"inklude": idx})
         self.tracer.pop()

--- a/kreate/kube/_kust.py
+++ b/kreate/kube/_kust.py
@@ -1,7 +1,7 @@
 import logging
 
 from ..kore import JinYamlKomponent, Module, App
-from .resource import Resource
+from .resource import Resource, MultiDocumentResource
 from .patch import Patch
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,8 @@ class KustomizeModule(Module):
 
 class Kustomization(JinYamlKomponent):
     def resources(self):
-        return [res for res in self.app.komponents if isinstance(res, Resource)]
+        return [res for res in self.app.komponents if
+                (isinstance(res, Resource) or isinstance(res, MultiDocumentResource))]
 
     def patches(self):
         return [res for res in self.app.komponents if isinstance(res, Patch)]

--- a/kreate/kube/resource.py
+++ b/kreate/kube/resource.py
@@ -1,6 +1,7 @@
 import logging
 
 from ..kore import JinYamlKomponent, wrap
+from ..kore._komp import MultiJinYamlKomponent
 from ..krypt.krypt_functions import dekrypt_str
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,14 @@ __all__ = [
     "ConfigMap",
     "Egress",
 ]
+
+
+class MultiDocumentResource(MultiJinYamlKomponent):
+    def __str__(self):
+        return f"<MultiDocumentResource {self.kind}.{self.shortname} {self.name}>"
+
+    def get_filename(self):
+        return f"resources/{self.kind}-{self.name}.yaml"
 
 
 class Resource(JinYamlKomponent):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "cryptography",
     "requests>=2.31.0",
     "packaging>=23.2",
+    "flatdict>=4.0.0",
 ]
 
 # This is needed for a namespace packages without __init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "cryptography",
     "requests>=2.31.0",
     "packaging>=23.2",
-    "flatdict>=4.0.0",
 ]
 
 # This is needed for a namespace packages without __init__.py


### PR DESCRIPTION
One can now use:

`kreate v flat for properties/flat view`
or 
`kreate v y for yaml view` (`kreate v` will still use yaml as default view

flat/properties view will look like:
```
val.HttpProbes.readiness_failureThreshold=1
val.HttpProbes.readiness_path=bc/actuator/info
val.HttpProbes.readiness_periodSeconds=2
val.HttpProbes.readiness_port=8080
val.HttpProbes.readiness_scheme=HTTP
```
which you can also easily 'grep' and you can still easily see in which section certein values were present
