### PR TITLE
Skip resources not found in mapper

### DIFF
--- a/kreate/kube/vardiff.py
+++ b/kreate/kube/vardiff.py
@@ -76,7 +76,10 @@ def dump_helper(cli: Cli, app: App,  kind_filter: str = None, name_mapper: dict 
         if name_mapper:
             if len(name) > 11:
                 trunc_name = name[:-11]
-                old_name =  name_mapper[trunc_name]
+                if trunc_name not in name_mapper:
+                    logger.warning(f"Could not find {trunc_name} in mapper list, skipping...")
+                    continue
+                old_name = name_mapper[trunc_name]
                 logger.info(f"changing name from {name} to {old_name}")
                 doc.get("metadata")["name"] = old_name
                 name = old_name


### PR DESCRIPTION
Previously stalled on files. Now it mentions it cannot find such a resource and continues. This way we can view the diff of the  other configmaps which might contain vars.