### PR TITLE
Add --server-side to the kubectl commands, else litteral comparison breaks on added/removed fields

### DIFF
--- a/kreate/kube/framework/define-commands.konf
+++ b/kreate/kube/framework/define-commands.konf
@@ -8,19 +8,19 @@ system:
       script: kubectl kustomize {target_dir}
     diff:
       help: run kubectl diff
-      script:  kubectl --context {konfig.app.env} -n {konfig.app.namespace} diff  -k {target_dir}
+      script:  kubectl --context {konfig.app.env} -n {konfig.app.namespace} diff  -k {target_dir} --server-side
     diff-file:
       help: run kubectl diff for a specific file
-      script:  kubectl --context {konfig.app.env} -n {konfig.app.namespace} diff -f {file}
+      script:  kubectl --context {konfig.app.env} -n {konfig.app.namespace} diff -f {file} --server-side
     getyaml:
         help: run kubectl get
         script:  kubectl --context {konfig.app.env} -n {konfig.app.namespace} get {resource_type} {resource_name} -o yaml
     apply:
       help: run kubectl apply
-      script: kubectl --context {konfig.app.env} -n {konfig.app.namespace} apply -k {target_dir}
+      script: kubectl --context {konfig.app.env} -n {konfig.app.namespace} apply -k {target_dir} --server-side
     dry-run:
       help: run kubectl apply --dry-run=server
-      script: kubectl --context {konfig.app.env} -n {konfig.app.namespace} apply --dry-run=server -k {target_dir}
+      script: kubectl --context {konfig.app.env} -n {konfig.app.namespace} apply --dry-run=server -k {target_dir} --server-side
     # example of a new command, that can be run with the run subcommand
     ls:
       help: list all files that are kreated


### PR DESCRIPTION
The diff comparison breaks on a json format error when adding or removing new literals for the config-maps when not using server-side. 

We only tested it for appy and diff, but i assume the same logic applies on dry-run and diff-file

Letting the compare be executed on the server-side fixed this issue for us.
It also gives some other benefits https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/
