### PR TITLE
use of autoscaling v2 instead of deprecated v2beta2

### DIFF
--- a/kreate/kube/templates/kubernetes/HorizontalPodAutoscaler.yaml
+++ b/kreate/kube/templates/kubernetes/HorizontalPodAutoscaler.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ my.name }}


### PR DESCRIPTION
As of K8's v1.26 this will be removed.